### PR TITLE
(#9) Remove apostrophe(s) only from ends of file path

### DIFF
--- a/src/checksum/Program.cs
+++ b/src/checksum/Program.cs
@@ -155,7 +155,7 @@ namespace checksum
             if (string.IsNullOrWhiteSpace(configuration.FilePath)) show_help(option_set);
 
 
-            configuration.FilePath = configuration.FilePath.Replace("'", string.Empty).Replace("\"", string.Empty).Trim();
+            configuration.FilePath = configuration.FilePath.Trim('\'').Replace("\"", string.Empty).Trim();
             if (!string.IsNullOrWhiteSpace(configuration.HashType))
             {
                 configuration.HashType = configuration.HashType.Trim();


### PR DESCRIPTION
## Description Of Changes

Instead of replacing apostrophes, they are trimed them from both ends of the file path.

## Motivation and Context

This allows checksuming of files within a user directory where the user's account name
contains an apostrophe. 

## Testing

1. Built checksum.exe
2. Copied to `$env:ChocolateyInstall\tools`, overwriting the pre-existing checksum.exe
3. Ran `choco install 4k-video-downloader` from an admin account with a name that contains an apostrophe

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #9