### PR TITLE
(#12) Fix typo in settings.kts

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,7 +65,7 @@ object Checksum : BuildType({
 
     features {
         pullRequests {
-            provider = githab {
+            provider = github {
                 authType = token {
                     token = "%system.GitHubPAT%"
                 }


### PR DESCRIPTION
## Description Of Changes

Fixes a typo of "github" which causes the kts file to not import.

## Motivation and Context

We need to be able to import this kts file.

## Testing

The original kts file was synced into TeamCity and it reported this error. The changed string matches other kts files in this org.

### Operating Systems Testing
 n/a

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#12 
